### PR TITLE
Update CardSlider props

### DIFF
--- a/src/components/Priorities.vue
+++ b/src/components/Priorities.vue
@@ -17,7 +17,7 @@
 
           <!-- INFRASTRUCTURE -->
           <div class="col s12 l4">
-            <CardSlider class="hoverable" imageName="cross-road-above.jpg" title="Infrastructure">
+            <CardSlider altText="Top down view of well organized roads, situated against a nature backdrop." class="hoverable" imageName="cross-road-above.jpg" title="Infrastructure">
               <p class="flow-text ward12-card-info">
                 <span class="ward12-card-info--huge">C</span>urrent Road Infrastructure is
                 not suitable to handle the traffic coming from new developments in
@@ -30,7 +30,7 @@
 
           <!-- TRAFFIC -->
           <div class="col s12 l4">
-            <CardSlider class="hoverable" imageName="traffic-jam.jpg" title="Traffic">
+            <CardSlider altText="Cars stuck in an urban traffic jam." class="hoverable" imageName="traffic-jam.jpg" title="Traffic">
               <p class="flow-text ward12-card-info">
                 <span class="ward12-card-info--huge">T</span>he situation regarding slow traffic
                 on the Mohawk ramp needs to be addressed. Previous discussions explored both
@@ -44,7 +44,7 @@
 
           <!-- Boundaries -->
           <div class="col s12 l4">
-            <CardSlider class="hoverable" imageName="Ward_Boundaries_2018-1024.png" title="Boundaries">
+            <CardSlider altText="A map of Hamilton's ward boundaries." class="hoverable" imageName="Ward_Boundaries_2018-1024.png" title="Boundaries">
               <p class="flow-text ward12-card-info">
                 <span class="ward12-card-info--huge">W</span>ith the recent boundary changes
                 there is a clear challenge to meet both urban and rural needs. It is clear

--- a/src/components/Priorities.vue
+++ b/src/components/Priorities.vue
@@ -17,7 +17,7 @@
 
           <!-- INFRASTRUCTURE -->
           <div class="col s12 l4">
-            <CardSlider altText="Top down view of well organized roads, situated against a nature backdrop." class="hoverable" imageName="cross-road-above.jpg" title="Infrastructure">
+            <CardSlider altText="Top down view of well organized roads, situated against a nature backdrop." class="hoverable" :image="require('@/assets/cross-road-above.jpg')" title="Infrastructure">
               <p class="flow-text ward12-card-info">
                 <span class="ward12-card-info--huge">C</span>urrent Road Infrastructure is
                 not suitable to handle the traffic coming from new developments in
@@ -30,7 +30,7 @@
 
           <!-- TRAFFIC -->
           <div class="col s12 l4">
-            <CardSlider altText="Cars stuck in an urban traffic jam." class="hoverable" imageName="traffic-jam.jpg" title="Traffic">
+            <CardSlider altText="Cars stuck in an urban traffic jam." class="hoverable" :image="require('@/assets/traffic-jam.jpg')" title="Traffic">
               <p class="flow-text ward12-card-info">
                 <span class="ward12-card-info--huge">T</span>he situation regarding slow traffic
                 on the Mohawk ramp needs to be addressed. Previous discussions explored both
@@ -44,7 +44,7 @@
 
           <!-- Boundaries -->
           <div class="col s12 l4">
-            <CardSlider altText="A map of Hamilton's ward boundaries." class="hoverable" imageName="Ward_Boundaries_2018-1024.png" title="Boundaries">
+            <CardSlider altText="A map of Hamilton's ward boundaries." class="hoverable" :image="require('@/assets/Ward_Boundaries_2018-1024.png')" title="Boundaries">
               <p class="flow-text ward12-card-info">
                 <span class="ward12-card-info--huge">W</span>ith the recent boundary changes
                 there is a clear challenge to meet both urban and rural needs. It is clear

--- a/src/components/common/CardSlider.vue
+++ b/src/components/common/CardSlider.vue
@@ -27,20 +27,22 @@
 <script>
 import Card from '@/components/common/Card'
 
+/**
+ * A reusable Card component. Contains a click-able image that reveals text.
+ * Child nodes are the inner card (revealed 'under' image).
+ *
+ * @vue-prop {String} altText - Required. Textual description for the provided image
+ * @vue-prop {String} image - Required. Fully qualified path to an image asset.
+ * @vue-prop {String} title - Required. Title, appears on card front alongside image.
+ */
 export default {
   name: 'CardSlider',
   components: { Card },
 
   props: {
     altText: String,
-    imageName: String,
+    image: String,
     title: String
-  },
-
-  data () {
-    return {
-      image: require(`@/assets/${this.imageName}`)
-    }
   }
 }
 </script>

--- a/src/components/common/CardSlider.vue
+++ b/src/components/common/CardSlider.vue
@@ -2,7 +2,7 @@
   <Card class="card-slider">
 
     <div class="card-image waves-effect waves-block waves-light">
-      <img class="card-slider__img activator" :src="image">
+      <img :alt="altText" class="card-slider__img activator" :src="image">
     </div>
 
     <div class="card-content card-slider__content">
@@ -32,6 +32,7 @@ export default {
   components: { Card },
 
   props: {
+    altText: String,
     imageName: String,
     title: String
   },


### PR DESCRIPTION
## CardSlider.vue
- :new: prop `altText`
- modified prop `imageName` ➡️ `image`
  + provide fully qualified asset path (ie Load in parent, not in CardSlider).
```
:image="require('@/assets/...')"
```

## Priorities.vue
- include alt text for CardSlider images
- Update `imageName` prop to use new `image` prop