### PR TITLE
Move Nav.vue to HomeNav.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 File: App.vue
 
 Description: Entry Vue Component. Listed components are always
-viewable. <main> section contains routed content.
+viewable.
 
 Author: Vapurrmaid <vapurrmaid@gmail.com>
 
@@ -14,13 +14,8 @@ The members of {@link https://github.com/KevinMarley} hold the sole rights
 for contribution and modification.
 -->
 <template>
-  <div
-    :class="{ 'application-hidden' : isNavDrawerOpen }"
-    id="app">
-    <Nav />
-    <main>
-      <router-view></router-view>
-    </main>
+  <div :class="{ 'application-hidden' : isNavDrawerOpen }" id="app">
+    <router-view></router-view>
     <Footer />
   </div>
 </template>
@@ -28,11 +23,14 @@ for contribution and modification.
 <script>
 import { mapGetters } from 'vuex'
 import Footer from '@/components/Footer'
-import Nav from '@/components/Nav'
 
+/**
+ * Exports root Vue Component. Child components are
+ * always-viewable.
+ */
 export default {
   name: 'App',
-  components: { Footer, Nav },
+  components: { Footer },
   computed: mapGetters('application', ['isNavDrawerOpen'])
 }
 </script>

--- a/src/components/TheHomeNav.vue
+++ b/src/components/TheHomeNav.vue
@@ -1,8 +1,8 @@
 <!--
-File: Nav.vue
+File: TheHomeNav.vue
 
-Description: Navigation Menu. Hamburger menu open/closes
-a navigation drawer.
+Description: Navigation Menu for the Home Page. Renders as
+a hamburger menu button that triggers a navigation drawer.
 
 Author: Vapurrmaid <vapurrmaid@gmail.com>
 
@@ -14,15 +14,15 @@ The members of {@link https://github.com/KevinMarley} hold the sole rights
 for contribution and modification.
 -->
 <template>
-  <div class="navigation">
+  <div class="home-navigation">
 
     <!-- Hamburger Menu -->
     <div
       @click="toggleNavDrawer"
-      class="navigation__btn">
+      class="home-navigation__btn">
       <span
-        :class="{ 'navigation__hamburger--open' : isNavDrawerOpen, 'navigation__hamburger--closed' : !isNavDrawerOpen }"
-        class="u-center navigation__hamburger">
+        :class="{ 'home-navigation__hamburger--open' : isNavDrawerOpen, 'home-navigation__hamburger--closed' : !isNavDrawerOpen }"
+        class="u-center home-navigation__hamburger">
         &nbsp;
       </span>
     </div>
@@ -46,7 +46,7 @@ import Drawer from '@/components/Drawer'
  * @property {function} toggleNavDrawer
  */
 export default {
-  name: 'Nav',
+  name: 'HomeNav',
   components: { Drawer },
   computed: mapGetters('application', ['isNavDrawerOpen']),
   methods: mapActions('application', ['toggleNavDrawer'])
@@ -56,7 +56,7 @@ export default {
 <style lang="scss">
 @import '../sass/abstracts/variables';
 
-.navigation {
+.home-navigation {
   &__btn {
     // sizing
     width: $hamburger-height;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -14,10 +14,13 @@ for contribution and modification.
 -->
 <template>
   <div>
+    <HomeNav />
     <Header />
-    <Meet />
-    <Priorities />
-    <Election />
+    <main>
+      <Meet />
+      <Priorities />
+      <Election />
+    </main>
   </div>
 </template>
 
@@ -25,14 +28,20 @@ for contribution and modification.
 import Election from '@/components/Election'
 import Header from '@/components/Header'
 import Meet from '@/components/Meet'
+import HomeNav from '@/components/TheHomeNav'
 import Priorities from '@/components/Priorities'
 
+/**
+ * Exports Vue Component representing a 'view' for
+ * Home (otherwise considered 'Home Page'
+ */
 export default {
   name: 'Home',
   components: {
     Election,
     Header,
     Meet,
+    HomeNav,
     Priorities
   }
 }

--- a/tests/unit/Home.spec.js
+++ b/tests/unit/Home.spec.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+
+import { mount } from '@vue/test-utils'
+import { expect } from 'chai'
+import Home from '@/views/Home'
+
+// stubs
+import Election from '@/components/Election'
+import Header from '@/components/Header'
+import Meet from '@/components/Meet'
+import HomeNav from '@/components/TheHomeNav'
+import Priorities from '@/components/Priorities'
+
+const STUBBED_COMPONENTS = [
+  HomeNav,
+  Header,
+  Meet,
+  Priorities,
+  Election
+]
+
+describe('Home View', function () {
+  beforeEach(function () {
+    this.wrapper = mount(Home, {
+      stubs: {
+        Election: true,
+        Header: true,
+        Meet: true,
+        HomeNav: true,
+        Priorities: true
+      }
+    })
+  })
+
+  // smoke test for each component
+  it('renders each component', function () {
+    STUBBED_COMPONENTS.forEach(component => {
+      expect(this.wrapper.find(component).exists()).to.equal(true)
+    })
+  })
+
+  // smoke test for semantic tag <main>
+  it('has a <main> tag', function () {
+    expect(this.wrapper.find('div > main').exists()).to.equal(true)
+  })
+})

--- a/tests/unit/HomeNav.spec.js
+++ b/tests/unit/HomeNav.spec.js
@@ -5,7 +5,7 @@ import Vuex from 'vuex'
 import { expect } from 'chai'
 import { mockAction } from '../helpers'
 import ApplicationModule from '@/store/modules/application'
-import Nav from '@/components/Nav'
+import HomeNav from '@/components/TheHomeNav'
 
 // setup a localVue for a mocked vuex application
 const localVue = createLocalVue()
@@ -30,32 +30,32 @@ describe('Nav', function () {
       }
     })
 
-    this.wrapper = shallowMount(Nav, { store, localVue })
+    this.wrapper = shallowMount(HomeNav, { store, localVue })
   })
 
   // smoke test
-  it('renders a root div with class navigation', function () {
+  it('renders a root div with class home-navigation', function () {
     expect(this.wrapper.classes())
       .to.be.an('array')
-      .that.includes('navigation')
+      .that.includes('home-navigation')
       .and.has.lengthOf(1)
   })
 
   // check clicking the hamburger triggers store action
   it('clicking the hamburger button triggers toggleNavDrawer action', function () {
     expect(this.toggleNavDrawerAction.getCalled()).to.equal(0)
-    const btn = this.wrapper.find('.navigation__btn')
+    const btn = this.wrapper.find('.home-navigation__btn')
     btn.trigger('click')
     expect(this.toggleNavDrawerAction.getCalled()).to.equal(1)
   })
 
   // check reacts to store getter - closed case
   it('the hamburger class is initially closed', function () {
-    const hamburger = this.wrapper.find('.navigation__hamburger')
+    const hamburger = this.wrapper.find('.home-navigation__hamburger')
     expect(hamburger.classes())
       .to.be.an('array')
-      .that.includes('navigation__hamburger--closed')
-      .and.not.includes('navigation__hamburger--open')
+      .that.includes('home-navigation__hamburger--closed')
+      .and.not.includes('home-navigation__hamburger--open')
   })
 
   // check reacts to store getter - open case
@@ -73,10 +73,10 @@ describe('Nav', function () {
         }
       }
     })
-    const hamburger = shallowMount(Nav, { store, localVue }).find('.navigation__hamburger')
+    const hamburger = shallowMount(HomeNav, { store, localVue }).find('.home-navigation__hamburger')
     expect(hamburger.classes())
       .to.be.an('array')
-      .that.includes('navigation__hamburger--open')
-      .and.not.includes('navigation__hamburger--close')
+      .that.includes('home-navigation__hamburger--open')
+      .and.not.includes('home-navigation__hamburger--close')
   })
 })


### PR DESCRIPTION
resolves #33 

* App.vue: Remove `<Nav />` and `<main>`. Both tags will now appear
in Views (or other components).

* HomeNav.vue: Update classnames and comments to reflect new semantic

* Home.vue: Add `<HomeNav />` component, add content to `<main>`